### PR TITLE
feature/썸네일 서버로 업로드

### DIFF
--- a/src/api/event-register-api.ts
+++ b/src/api/event-register-api.ts
@@ -1,9 +1,42 @@
 import { PLACEHOLDER_IMAGE } from "@/constants/default-images"
+import { getImageServerUrl } from "@/constants/env"
 
 import { EventFormData, EventRequestData, EventType, PriceGrade } from "@/types/event"
 import { ScheduleFormData } from "@/types/schedule"
 
 import { client } from "./client"
+
+// 이미지 URL을 게이트웨이를 통해 완전한 URL로 변환하는 함수
+const convertToFullImageUrl = (imageUrl: string): string => {
+  if (!imageUrl) return PLACEHOLDER_IMAGE
+
+  // 이미 완전한 URL인 경우 그대로 반환
+  if (imageUrl.startsWith("http://") || imageUrl.startsWith("https://")) {
+    return imageUrl
+  }
+
+  // 상대 경로인 경우 게이트웨이를 통해 변환
+  if (imageUrl.startsWith("/")) {
+    return `${getImageServerUrl()}${imageUrl}`
+  }
+
+  // 상대 경로가 아닌 경우도 게이트웨이를 통해 변환
+  return `${getImageServerUrl()}/${imageUrl}`
+}
+
+// HTML description 내의 이미지 URL을 게이트웨이를 통해 완전한 URL로 변환하는 함수
+const convertImageUrlsInDescription = (description: string | undefined): string => {
+  if (!description) return description || ""
+
+  // src="/event/uploads/..." 패턴을 찾아서 게이트웨이를 통해 완전한 URL로 변환
+  const imageServerUrl = getImageServerUrl()
+  const convertedDescription = description.replace(
+    /src="\/event\/uploads\/([^"]+)"/g,
+    `src="${imageServerUrl}/uploads/$1"`
+  )
+
+  return convertedDescription
+}
 
 // DB 응답 타입 정의 (JOIN 결과)
 interface DbEventResponse {
@@ -63,7 +96,7 @@ const convertDbResponseToEventType = (dbResponse: DbEventResponse): EventType =>
     genre: dbResponse.genre || "",
     description: dbResponse.description || "",
     eventScheduleId: dbResponse.eventScheduleId || 1,
-    thumbnailUrl: dbResponse.thumbnailUrl,
+    thumbnailUrl: convertToFullImageUrl(dbResponse.thumbnailUrl),
     status: dbResponse.status as "PENDING" | "APPROVED" | "REJECTED",
     prices: dbResponse.prices.map((price) => ({
       priceId: price.priceId || 1, // priceId 추가
@@ -110,13 +143,6 @@ export const createEventRequestData = (
   accountId: number,
   isEditMode: boolean = false
 ): EventRequestData => {
-  console.log("=== createEventRequestData 디버깅 ===")
-  console.log("isEditMode:", isEditMode)
-  console.log("eventData:", eventData)
-  console.log("scheduleForm:", scheduleForm)
-  console.log("accountId:", accountId)
-  console.log("==========================")
-
   const isValidTime = (hour: string, minute: string) => {
     return hour && minute && hour !== "" && minute !== ""
   }
@@ -168,25 +194,29 @@ export const createEventRequestData = (
     ],
   }
 
-  console.log("=== 생성된 결과 ===")
-  console.log("result:", result)
-  console.log("==========================")
-
   return result
 }
 
 export const submitEvent = async (
   requestData: EventRequestData,
-  accountId: number
+  accountId: number,
+  thumbnailFile?: File
 ): Promise<void> => {
-  console.log("=== 공연 등록 API 호출 ===")
-  console.log("URL:", `/api/events/tenant`)
-  console.log("accountId:", accountId)
-  console.log("requestData:", JSON.stringify(requestData, null, 2))
-  console.log("==========================")
+  const formData = new FormData()
 
-  const response = await client.post(`/api/events/tenant`, requestData, {
+  // eventData를 JSON 문자열로 변환하여 추가
+  formData.append("eventData", JSON.stringify(requestData))
+
+  // 썸네일 파일이 있으면 추가
+  if (thumbnailFile) {
+    formData.append("thumbnail", thumbnailFile)
+  }
+
+  const response = await client.post(`/api/events/tenant`, formData, {
     params: { accountId },
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
   })
 
   if (!response.data.success) {
@@ -197,41 +227,47 @@ export const submitEvent = async (
 export const updateEvent = async (
   requestData: EventRequestData,
   eventId: number,
-  accountId: number
+  accountId: number,
+  thumbnailFile?: File
 ): Promise<void> => {
-  console.log("=== 공연 수정 API 호출 ===")
-  console.log("URL:", `/api/events/tenant/${eventId}`)
-  console.log("eventId:", eventId)
-  console.log("accountId:", accountId)
-  console.log("requestData:", JSON.stringify(requestData, null, 2))
-  console.log("==========================")
+  const formData = new FormData()
 
-  const response = await client.put(
-    `/api/events/tenant/${eventId}`,
-    {
-      eventId: eventId,
-      title: requestData.title,
-      ageLimit: requestData.ageLimit,
-      description: requestData.description,
-      genre: requestData.genre,
-      thumbnailUrl: requestData.thumbnailUrl,
-      status: "PENDING",
-      schedules: requestData.schedules.map((schedule) => ({
-        eventScheduleId: schedule.eventScheduleId || 1, // requestData에서 전달받은 실제 스케줄 ID 사용
-        venueId: schedule.venueId,
-        ticketOpenAt: schedule.ticketOpenAt,
-        eventDate: schedule.eventDate,
-        prices: schedule.prices.map((price) => ({
-          priceId: price.priceId || 1, // requestData에서 전달받은 실제 가격 ID 사용
-          seatClassId: price.seatClassId,
-          price: price.price,
-        })),
+  // 업데이트할 데이터 구성
+  const updateData = {
+    eventId: eventId,
+    title: requestData.title,
+    ageLimit: requestData.ageLimit,
+    description: requestData.description,
+    genre: requestData.genre,
+    thumbnailUrl: requestData.thumbnailUrl,
+    status: "PENDING",
+    schedules: requestData.schedules.map((schedule) => ({
+      eventScheduleId: schedule.eventScheduleId || 1, // requestData에서 전달받은 실제 스케줄 ID 사용
+      venueId: schedule.venueId,
+      ticketOpenAt: schedule.ticketOpenAt,
+      eventDate: schedule.eventDate,
+      prices: schedule.prices.map((price) => ({
+        priceId: price.priceId || 1, // requestData에서 전달받은 실제 가격 ID 사용
+        seatClassId: price.seatClassId,
+        price: price.price,
       })),
+    })),
+  }
+
+  // eventData를 JSON 문자열로 변환하여 추가
+  formData.append("eventData", JSON.stringify(updateData))
+
+  // 썸네일 파일이 있으면 추가
+  if (thumbnailFile) {
+    formData.append("thumbnail", thumbnailFile)
+  }
+
+  const response = await client.put(`/api/events/tenant/${eventId}`, formData, {
+    params: { accountId },
+    headers: {
+      "Content-Type": "multipart/form-data",
     },
-    {
-      params: { accountId },
-    }
-  )
+  })
 
   if (!response.data.success) {
     throw new Error("공연 수정에 실패했습니다.")
@@ -242,11 +278,7 @@ export const getEvents = async (accountId: number): Promise<EventType[]> => {
   try {
     const response = await client.get(`/api/events?accountId=${accountId}`)
 
-    console.log("API 응답 상태:", response.status)
-    console.log("API 응답 헤더:", response.headers)
-
     if (!response.data.success) {
-      console.error("API 에러 응답:", response.data)
       throw new Error(`공연 목록 조회에 실패했습니다. (${response.status})`)
     }
 
@@ -276,7 +308,8 @@ export const getEvents = async (accountId: number): Promise<EventType[]> => {
         const eventWithStatus = {
           ...firstItem,
           status: firstItem.status || "PENDING", // 기본값으로 PENDING 설정
-          thumbnailUrl: firstItem.thumbnailUrl || PLACEHOLDER_IMAGE, // 기본 이미지 설정
+          thumbnailUrl: convertToFullImageUrl(firstItem.thumbnailUrl), // 이미지 URL 변환
+          description: convertImageUrlsInDescription(firstItem.description), // description 내 이미지 URL 변환
         }
 
         // 이미 EventType 형식인 경우 그대로 사용
@@ -326,23 +359,18 @@ export const getEventById = async (eventId: number, accountId: number): Promise<
       params: { accountId },
     })
 
-    console.log("API 응답 상태:", response.status)
-    console.log("API 응답 데이터:", response.data)
-
     if (!response.data.success) {
-      console.error("API 에러 응답:", response.data)
       throw new Error(`공연 상세 조회에 실패했습니다. (${response.status})`)
     }
 
     // API 응답에서 data 필드 추출
     const eventData = response.data.data || response.data
-    console.log("이벤트 상세 데이터:", eventData)
 
-    // status와 thumbnailUrl에 기본값 설정
+    // thumbnailUrl과 description 내 이미지 URL 변환
     const eventWithDefaults = {
       ...eventData,
-      status: eventData.status || "PENDING",
-      thumbnailUrl: eventData.thumbnailUrl || PLACEHOLDER_IMAGE,
+      thumbnailUrl: convertToFullImageUrl(eventData.thumbnailUrl),
+      description: convertImageUrlsInDescription(eventData.description),
     }
 
     // 이미 EventType 형식인 경우 그대로 사용
@@ -393,7 +421,8 @@ export const getTenantSchedules = async (accountId: number): Promise<EventType[]
         const eventWithStatus = {
           ...firstItem,
           status: firstItem.status || "PENDING", // 기본값으로 PENDING 설정
-          thumbnailUrl: firstItem.thumbnailUrl || PLACEHOLDER_IMAGE, // 기본 이미지 설정
+          thumbnailUrl: convertToFullImageUrl(firstItem.thumbnailUrl), // 이미지 URL 변환
+          description: convertImageUrlsInDescription(firstItem.description), // description 내 이미지 URL 변환
         }
 
         // 이미 EventType 형식인 경우 그대로 사용
@@ -446,23 +475,18 @@ export const getTenantEventDetail = async (
       params: { accountId },
     })
 
-    console.log("API 응답 상태:", response.status)
-    console.log("API 응답 데이터:", response.data)
-
     if (!response.data.success) {
-      console.error("API 에러 응답:", response.data)
       throw new Error(`테넌트 이벤트 상세 조회에 실패했습니다. (${response.status})`)
     }
 
     // API 응답에서 data 필드 추출
     const eventData = response.data.data || response.data
-    console.log("이벤트 상세 데이터:", eventData)
 
-    // status와 thumbnailUrl에 기본값 설정
+    // thumbnailUrl과 description 내 이미지 URL 변환
     const eventWithDefaults = {
       ...eventData,
-      status: eventData.status || "PENDING",
-      thumbnailUrl: eventData.thumbnailUrl || PLACEHOLDER_IMAGE,
+      thumbnailUrl: convertToFullImageUrl(eventData.thumbnailUrl),
+      description: convertImageUrlsInDescription(eventData.description),
     }
 
     // 이미 EventType 형식인 경우 그대로 사용
@@ -479,7 +503,7 @@ export const getTenantEventDetail = async (
 
 export const deleteEvent = async (eventId: number): Promise<void> => {
   try {
-    const response = await client.delete(`/api/events/tenant/${eventId}`)
+    const response = await client.post(`/api/events/tenant/${eventId}`)
 
     if (!response.data.success) {
       throw new Error(`Failed to delete event: ${response.status}`)

--- a/src/components/table/events-table.tsx
+++ b/src/components/table/events-table.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { CalendarIcon, MapPinIcon, UsersIcon } from "@heroicons/react/20/solid"
 import { format, isBefore } from "date-fns"
+import { useNavigate } from "react-router-dom"
 
 import { Badge } from "@/components/catalyst-ui/badge"
 import {
@@ -22,6 +23,8 @@ interface EventsTableProps {
 }
 
 const EventsTable: React.FC<EventsTableProps> = ({ events, loading }) => {
+  const navigate = useNavigate()
+
   const getStatusBadge = (eventDate: string) => {
     const now = new Date()
     const eventDateTime = new Date(eventDate)
@@ -35,6 +38,14 @@ const EventsTable: React.FC<EventsTableProps> = ({ events, loading }) => {
 
   const formatDate = (dateString: string) => {
     return format(new Date(dateString), "yyyy년 MM월 dd일")
+  }
+
+  const handleEventClick = (event: MonthlyEvent) => {
+    navigate(`/events`, {
+      state: {
+        searchTitle: event.title, // 이벤트 목록에서 검색할 제목
+      },
+    })
   }
 
   if (loading) {
@@ -110,7 +121,12 @@ const EventsTable: React.FC<EventsTableProps> = ({ events, loading }) => {
         {events.map((event, index) => (
           <TableRow key={index}>
             <TableCell>
-              <Text className="font-medium">{event.title}</Text>
+              <Text
+                className="font-medium text-blue-600 hover:text-blue-800 cursor-pointer transition-colors"
+                onClick={() => handleEventClick(event)}
+              >
+                {event.title}
+              </Text>
             </TableCell>
             <TableCell>
               <div className="flex items-center gap-2">

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -34,6 +34,12 @@ const BFF_API_URL: Record<Environment, string> = {
   dev: `${GATEWAY_URL.dev}/bff`,
 }
 
+// 이미지 서버 URL (게이트웨이 도메인 + 8081 포트)
+const IMAGE_SERVER_URL: Record<Environment, string> = {
+  local: GATEWAY_URL.local.replace(":8087", ":8081"),
+  dev: GATEWAY_URL.dev.replace(":8087", ":8081"),
+}
+
 // 함수로 API URL 가져오기 (다른 웹 프로젝트와 동일한 방식)
 export const getGatewayUrl = () => GATEWAY_URL[ENV]
 export const getEventApiUrl = () => EVENT_API_URL[ENV]
@@ -41,6 +47,7 @@ export const getAccountApiUrl = () => ACCOUNT_API_URL[ENV]
 export const getPaymentApiUrl = () => PAYMENT_API_URL[ENV]
 export const getBookingApiUrl = () => BOOKING_API_URL[ENV]
 export const getBffApiUrl = () => BFF_API_URL[ENV]
+export const getImageServerUrl = () => IMAGE_SERVER_URL[ENV]
 
 // 현재 환경의 API URL들 (기존 호환성 유지)
 export const CURRENT_EVENT_API_URL = EVENT_API_URL[ENV]

--- a/src/pages/bookings-page.tsx
+++ b/src/pages/bookings-page.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react"
 import { getBookings, getBookingsByEvent } from "@/api/booking-api"
-import baseClient from "@/api/client/base-client"
+import { bffClient } from "@/api/client"
 import { ArrowUturnLeftIcon } from "@heroicons/react/24/outline"
 import { useLocation, useNavigate, useParams } from "react-router-dom"
 
@@ -84,7 +84,7 @@ const BookingsPage = () => {
           queryParams.append("status", filters.status)
         }
 
-        const response = await baseClient.get(`/bff/api/v1/bookings?${queryParams.toString()}`)
+        const response = await bffClient.get(`/api/v1/bookings?${queryParams.toString()}`)
 
         const apiResponse: BookingApiResponse = response.data
 

--- a/src/pages/event-detail-page.tsx
+++ b/src/pages/event-detail-page.tsx
@@ -4,15 +4,16 @@ import {
   deleteEvent,
   getTenantEventDetail,
 } from "@/api/event-register-api"
+import { getEventApiUrl, getImageServerUrl } from "@/constants/env"
 import { event } from "@/constants/event"
 import EventCard from "@/pages/events-page/_components/event-card"
 import { useScheduleFormStore } from "@/store/schedule-form-store"
 import { convertEventToScheduleFormData } from "@/util/convertEventToScheduleFormData"
 import { getAccountId } from "@/utils/auth"
 import { ArrowUturnLeftIcon } from "@heroicons/react/16/solid"
-import { useNavigate, useParams } from "react-router-dom"
+import { useLocation, useNavigate, useParams } from "react-router-dom"
 
-import { EventFormData, EventType } from "@/types/event"
+import { EventFormData, EventStatus, EventType } from "@/types/event"
 import { Button } from "@/components/catalyst-ui/button"
 import {
   Table,
@@ -23,13 +24,36 @@ import {
   TableRow,
 } from "@/components/catalyst-ui/table"
 
+// HTML 내용에서 이미지 경로를 게이트웨이를 통해 완전한 URL로 변환하는 함수
+const convertImageUrlsInHtml = (htmlContent: string): string => {
+  if (!htmlContent) return htmlContent
+
+  // src="/event/uploads/..." 패턴을 찾아서 게이트웨이를 통해 올바른 경로로 변환
+  const imageServerUrl = getImageServerUrl()
+  const convertedHtml = htmlContent.replace(
+    /src="\/event\/uploads\/([^"]+)"/g,
+    `src="${imageServerUrl}/uploads/$1"`
+  )
+
+  return convertedHtml
+}
+
 const EventDetailPage = () => {
   const navigate = useNavigate()
+  const location = useLocation()
   const { eventId } = useParams<{ eventId: string }>()
   const [eventData, setEventData] = useState<EventType | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [useMockData, setUseMockData] = useState(false)
+
+  // 이전 페이지에서 전달받은 상태 정보
+  const previousState = location.state as {
+    status?: string
+    title?: string
+    venueName?: string
+    eventDate?: string
+  } | null
 
   // API에서 이벤트 상세 정보 가져오기
   useEffect(() => {
@@ -47,6 +71,12 @@ const EventDetailPage = () => {
         const accountId = getAccountId()
 
         const data = await getTenantEventDetail(parseInt(eventId), accountId)
+
+        // 이전 페이지에서 전달받은 status가 있으면 사용
+        if (previousState?.status) {
+          data.status = previousState.status as EventStatus
+        }
+
         setEventData(data)
         setUseMockData(false)
       } catch (err) {
@@ -123,13 +153,6 @@ const EventDetailPage = () => {
 
     // 기존 공연의 실제 데이터를 이벤트 폼에 설정
     const eventFormData = convertEventToFormData(eventData)
-
-    console.log("=== handleEdit 디버깅 ===")
-    console.log("원본 eventData:", eventData)
-    console.log("변환된 eventFormData:", eventFormData)
-    console.log("venueName:", eventData.venueName)
-    console.log("venue 필드:", eventFormData.venue)
-    console.log("==========================")
 
     navigate("/event-register", {
       state: {
@@ -308,7 +331,7 @@ const EventDetailPage = () => {
             {eventData.description ? (
               <div
                 className="prose max-w-none"
-                dangerouslySetInnerHTML={{ __html: eventData.description }}
+                dangerouslySetInnerHTML={{ __html: convertImageUrlsInHtml(eventData.description) }}
               />
             ) : (
               <p className="text-gray-500">상세정보가 없습니다.</p>

--- a/src/pages/events-page/_components/event-card.tsx
+++ b/src/pages/events-page/_components/event-card.tsx
@@ -19,9 +19,8 @@ const EventCard = ({ event, disableClick = false, showStatus = true, onClick }: 
     if (disableClick) return
 
     if (onClick) {
-      onClick() //예매현황 페이지에서는
+      onClick()
     } else {
-      // 기본은 event-detail-page로 이동함
       navigation(`/events/${event.eventId}`)
     }
   }

--- a/src/pages/events-page/events-page.tsx
+++ b/src/pages/events-page/events-page.tsx
@@ -4,7 +4,7 @@ import { eventList, STATUS_FILTER_OPTIONS } from "@/constants/event"
 import { getAccountId } from "@/utils/auth"
 import { searchEventsByTitle } from "@/utils/search"
 import { PlusIcon } from "@heroicons/react/16/solid"
-import { useNavigate } from "react-router-dom"
+import { useLocation, useNavigate } from "react-router-dom"
 
 import { EventType } from "@/types/event"
 import { Badge } from "@/components/catalyst-ui/badge"
@@ -17,8 +17,14 @@ import { Text } from "@/components/catalyst-ui/text"
 import EventCard from "./_components/event-card"
 
 const EventsPage = () => {
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  // 이전 페이지에서 전달받은 검색 제목
+  const previousState = location.state as { searchTitle?: string } | null
+
   const [activeStatus, setActiveStatus] = useState("ALL")
-  const [searchValue, setSearchValue] = useState("")
+  const [searchValue, setSearchValue] = useState(previousState?.searchTitle || "")
   const [sortBy, setSortBy] = useState("date")
   const [events, setEvents] = useState<EventType[]>([])
   const [loading, setLoading] = useState(true)
@@ -26,7 +32,6 @@ const EventsPage = () => {
   const [useMockData, setUseMockData] = useState(false)
   const [currentPage, setCurrentPage] = useState(1)
   const [itemsPerPage] = useState(7) // 페이지당 7개로 변경
-  const navigate = useNavigate()
 
   const sortOptions = [
     { value: "name", label: "이름순" },

--- a/src/pages/schedules-register-page.tsx
+++ b/src/pages/schedules-register-page.tsx
@@ -79,10 +79,10 @@ function SchedulesRegisterPage() {
 
     try {
       if (mode === "edit") {
-        await updateEvent(requestData, eventId, accountId)
+        await updateEvent(requestData, eventId, accountId, eventData.thumbnail)
         alert("공연이 성공적으로 수정되었습니다.")
       } else {
-        await submitEvent(requestData, accountId)
+        await submitEvent(requestData, accountId, eventData.thumbnail)
         alert("공연이 성공적으로 등록되었습니다.")
       }
 


### PR DESCRIPTION
## ✏️ 작업 개요  
description과 마찬가지로 서버로 thumbnail 업로드
메인페이지 내 event-table에서 공연명 클릭시 공연 리스트 조회 페이지 검색창으로 라우트

## 🔨 작업 내용 상세
- src/api/event-register-api.ts: 썸네일 업로드, 이미지 URL 변환 로직
- src/pages/event-detail-page.tsx: 이미지 표시, 상태 관리
- src/pages/event-register-page.tsx: 썸네일 업로드 UI
- src/pages/schedules-register-page.tsx: 썸네일 파일 전달
- src/components/table/events-table.tsx: 라우팅 로직
- src/pages/events-page/events-page.tsx: 검색창 자동 입력
- src/types/event.ts: 타입 정의 수정
- src/constants/env.ts: 이미지 서버 URL 설정성)

## 🔗 관련 이슈  
- Closes #29 

## ✅ 체크리스트  
- [ ] 테스트 코드 작성 완료
- [ ] 로컬에서 기능 정상 작동 확인
- [ ] Swagger UI에서 API 확인 완료
- [ ] 예외 처리 및 ResponseDto 적용
- [ ] 공통 모듈(공통 DTO, Exception 등) 사용 지침 준수
- [ ] Google Java Style Guide 및 네이밍 규칙 준수
- [ ] Flyway 마이그레이션 파일 작성 (필요 시)


## 💬 기타 참고 사항  
- 리뷰어가 참고하면 좋을 만한 내용 (예: 테스트 방법, 의도된 예외 처리 등)
